### PR TITLE
Fix regex for line comments (that did not work comments appearing at …

### DIFF
--- a/grammars/requirements.cson
+++ b/grammars/requirements.cson
@@ -4,8 +4,8 @@
   'requirements.txt'
 ]
 'patterns': [
-  {
-    'begin': '^([\\s]+)?(?=#)'
+  { # line comment : (spanning an entire line) | (at end of a regular line)
+    'begin': '(^([\\s]+)?(?=#))|(([\\s]+)(?=#))'
     'beginCaptures':
       '1':
         'name': 'punctuation.whitespace.comment.leading.pip'

--- a/spec/requirements-spec.coffee
+++ b/spec/requirements-spec.coffee
@@ -24,3 +24,27 @@ describe 'pip requirements grammar', ->
   it 'tokenizes version specifier ==', ->
     {tokens} = grammar.tokenizeLine '=='
     expect(tokens[0]).toEqual value: '==', scopes: ['text.pip.requirements', 'keyword.version-specifier.pip']
+
+  it 'tokenizes trailing line comments', ->
+    {tokens} = grammar.tokenizeLine 'coverage # trailing comments'
+    expect(tokens[0]).toEqual value: 'coverage', scopes: ['text.pip.requirements', 'meta.package-name.pip']
+    expect(tokens[1]).toEqual value: ' ', scopes: ['text.pip.requirements']
+    expect(tokens[2]).toEqual value: '#', scopes: ['text.pip.requirements', 'comment.line.number-sign.pip', 'punctuation.definition.comment.pip']
+    expect(tokens[3]).toEqual value: ' trailing comments', scopes: ['text.pip.requirements', 'comment.line.number-sign.pip']
+
+  it 'does NOT tokenize  trailing line comments in the absence of preceding whitespace', ->
+    {tokens} = grammar.tokenizeLine 'MyProject#egg=hatched'
+    expect(tokens[0]).toEqual value: 'MyProject', scopes: ['text.pip.requirements', 'meta.package-name.pip']
+    # [TABULON]: for some reason, this is tokenized separately (most probably unrelated to the change that introduced trailing comments),
+    #            Hwoever, it doesn't seem to hurt in any case  (since we are indeed avoiding to trigger a COMMENT scope)
+    expect(tokens[1]).toEqual value: '#egg=hatched', scopes: ['text.pip.requirements']
+
+  it 'correctly tokenizes trailing line comments, and respects the rule related to preceding whitespace', ->
+    {tokens} = grammar.tokenizeLine 'MyProject#egg=hatched # trailing comments'
+    expect(tokens[0]).toEqual value: 'MyProject', scopes: ['text.pip.requirements', 'meta.package-name.pip']
+    # [TABULON]: for some reason, this is tokenized separately (most probably unrelated to the change that introduced trailing comments),
+    #            Hwoever, it doesn't seem to hurt in any case  (since we are indeed avoiding to trigger a COMMENT scope)
+    expect(tokens[1]).toEqual value: '#egg=hatched', scopes: ['text.pip.requirements']
+    expect(tokens[2]).toEqual value: ' ', scopes: ['text.pip.requirements']
+    expect(tokens[3]).toEqual value: '#', scopes: ['text.pip.requirements', 'comment.line.number-sign.pip', 'punctuation.definition.comment.pip']
+    expect(tokens[4]).toEqual value: ' trailing comments', scopes: ['text.pip.requirements', 'comment.line.number-sign.pip']


### PR DESCRIPTION
This is a tiny change that fixes issue [#1], and hence enables comments at line endings to be duly recognized by atom `language-pip`.

For the description of the issue and more information, please refer to [#1].

As a side note, the **regex** could have been shortened a bit more, but imho it's more clear this way, and also easier to seperate out in a distinct block later, if needed.

Thnaks again,
Tabulo[n]

