### PR TITLE
Add "examples" directory with some content for pip requirements files

### DIFF
--- a/examples/requirements-example-basic.txt
+++ b/examples/requirements-example-basic.txt
@@ -1,0 +1,44 @@
+# ================================================================================
+# source: [pip docmentation](https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format)
+# ------------
+# Below is an excerpt from the pip documentation
+# relating to the format of 'requirements' files:
+#
+# > A line that begins with # is treated as a comment and ignored.
+# > Whitespace followed by a # causes the # and the remainder of the line to be treated as a comment.
+# ================================================================================
+
+# This is a COMMENT (spanning an entire line)
+  # This another COMMENT (which also spans en entire line), since those MAY be preceded by whitespace
+
+faker   # Another COMMENT (at the end of a regular line), which MUST be preceded by whitespace to count as a comment.
+jinja2 >= 2.10
+pytest
+six == 1.12.0
+
+# NOTE that '#' below  does NOT signal the start of a comment (since it is NOT preceded by whitespace)
+# This is a relief because the '#' character be present in regular strings (as in some URLs)
+[-e] git://git.example.com/MyProject#egg=MyProject
+
+
+# ------------------------------------------------------------------------------------------------
+# Other than the stop measure above (preceding whitespace), pip does not appear to define a generic
+# escaping mechanism for preventing the '#' char (preceded by whitespace) from starting a comment.
+# --
+# In practise, this does not really pose a problem, because it is so rarely needed, if ever.
+# In fact, the only place I can think of where this could eventually occur is in filenames
+# on systems where that is alowed, such as Unix/Linux.
+#
+# So, you are out of luck if you've got to deal with a weird file name
+# that contains whitespace followed by the '#' character.
+#
+# But, don't worry, pip itself cannot deal with it either:-)
+# So the fact that 'language-pip' basically mirrors the pip behaviour
+# is actually a good thing because this gives visual clue about the problem.
+# ------------------------------------------------------------------------------------------------
+# Here's a contrived example:
+-r "some weird file #1.txt"
+
+# If you really to refer to offending strings that can't be parsed by pip (like the above),
+# the following workaround appears to do the trick (as of the current pip version).
+-r "${WEIRDO}"  # where `WEIRDO` is an environment variable that already contains the offending string

--- a/examples/requirements-example-cases-from-pip-docs.txt
+++ b/examples/requirements-example-cases-from-pip-docs.txt
@@ -1,0 +1,100 @@
+# =============================================================================
+# Requirements File Format (EXAMPLES)
+# source: [pip documentation](https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format)
+# =============================================================================
+
+# ---------------------------------------------------------
+# Some options
+# ---------------------------------------------------------
+--no-index
+--find-links /my/local/archives
+--find-links http://some.archives.com/archives
+-r more_requirements.txt
+-c some_constraints.txt
+
+# ---------------------------------------------------------
+# REQUIREMENT SPECIFIERS
+# ---------------------------------------------------------
+
+# Some examples:
+SomeProject
+SomeProject == 1.3
+SomeProject >=1.2,<2.0
+SomeProject[foo, bar]
+SomeProject~=1.4.2
+
+# Since version 6.0, pip also supports specifiers containing environment markers like so:
+SomeProject ==5.4 ; python_version < '2.7'
+SomeProject; sys_platform == 'win32'
+
+# ---------------------------------------------------------
+# PER-REQUIREMENT OVERRIDES
+# ---------------------------------------------------------
+# The --global-option and --install-option options are used to pass options to setup.py.
+# For example:
+FooProject >= 1.2 --global-option="--no-user-cfg" \
+                  --install-option="--prefix='/usr/local'" \
+                  --install-option="--no-compile"
+
+# ---------------------------------------------------------
+# Using Environment Variables
+# ---------------------------------------------------------
+# Since version 10, pip also makes it possible to use environment variables
+# which makes it possible to reference private repositories
+# without having to store access tokens in the requirements file.
+[-e] git+http://${AUTH_USER}:${AUTH_PASSWORD}@git.example.com/MyProject#egg=MyProject
+[-e] git+https://${AUTH_USER}:${AUTH_PASSWORD}@git.example.com/MyProject#egg=MyProject
+
+
+# ---------------------------------------------------------
+# Hash-Checking Mode
+# ---------------------------------------------------------
+# Since version 8.0, pip can check downloaded package archives
+# against local hashes to protect against remote tampering.
+FooProject == 1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 \
+                  --hash=sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7
+
+
+# ---------------------------------------------------------
+# VCS Support
+# ---------------------------------------------------------
+# Git
+[-e] git://git.example.com/MyProject#egg=MyProject
+[-e] git+http://git.example.com/MyProject#egg=MyProject
+[-e] git+https://git.example.com/MyProject#egg=MyProject
+[-e] git+ssh://git.example.com/MyProject#egg=MyProject
+[-e] git+git://git.example.com/MyProject#egg=MyProject
+[-e] git+file:///home/user/projects/MyProject#egg=MyProject
+-e git+git@git.example.com:MyProject#egg=MyProject
+
+# Mercurial -- simple
+[-e] hg+http://hg.myproject.org/MyProject#egg=MyProject
+[-e] hg+https://hg.myproject.org/MyProject#egg=MyProject
+[-e] hg+ssh://hg.myproject.org/MyProject#egg=MyProject
+[-e] hg+file:///home/user/projects/MyProject#egg=MyProject
+
+# Mercurial -- complex
+[-e] hg+http://hg.example.com/MyProject@da39a3ee5e6b#egg=MyProject
+[-e] hg+http://hg.example.com/MyProject@2019#egg=MyProject
+[-e] hg+http://hg.example.com/MyProject@v1.0#egg=MyProject
+[-e] hg+http://hg.example.com/MyProject@special_feature#egg=MyProject
+
+# Subversion -- simple
+[-e] svn+https://svn.example.com/MyProject#egg=MyProject
+[-e] svn+ssh://svn.example.com/MyProject#egg=MyProject
+[-e] svn+ssh://user@svn.example.com/MyProject#egg=MyProject
+
+# Subversion -- complex
+[-e] svn+svn://svn.example.com/svn/MyProject#egg=MyProject
+[-e] svn+http://svn.example.com/svn/MyProject/trunk@2019#egg=MyProject
+
+# Bazaar -- simple
+[-e] bzr+http://bzr.example.com/MyProject/trunk#egg=MyProject
+[-e] bzr+sftp://user@example.com/MyProject/trunk#egg=MyProject
+[-e] bzr+ssh://user@example.com/MyProject/trunk#egg=MyProject
+[-e] bzr+ftp://user@example.com/MyProject/trunk#egg=MyProject
+[-e] bzr+lp:MyProject#egg=MyProject
+
+# Bazaar -- complex
+[-e] bzr+https://bzr.example.com/MyProject/trunk@2019#egg=MyProject
+[-e] bzr+http://bzr.example.com/MyProject/trunk@v1.0#egg=MyProject

--- a/examples/requirements-example-file-from-pip-docs.txt
+++ b/examples/requirements-example-file-from-pip-docs.txt
@@ -1,0 +1,28 @@
+#
+####### example-requirements.txt #######
+#
+###### Requirements without Version Specifiers ######
+nose
+nose-cov
+beautifulsoup4
+#
+###### Requirements with Version Specifiers ######
+#   See https://www.python.org/dev/peps/pep-0440/#version-specifiers
+docopt == 0.6.1             # Version Matching. Must be version 0.6.1
+keyring >= 4.1.1            # Minimum version 4.1.1
+coverage != 3.5             # Version Exclusion. Anything except version 3.5
+Mopidy-Dirble ~= 1.1        # Compatible release. Same as >= 1.1, == 1.*
+#
+###### Refer to other requirements files ######
+-r other-requirements.txt
+#
+#
+###### A particular file ######
+./downloads/numpy-1.9.2-cp34-none-win32.whl
+http://wxpython.org/Phoenix/snapshot-builds/wxPython_Phoenix-3.0.3.dev1820+49a8884-cp34-none-win_amd64.whl
+#
+###### Additional Requirements without Version Specifiers ######
+#   Same as 1st section, just here to show that you can put things in any order.
+rejected
+green
+#


### PR DESCRIPTION
This a "bonus" PR that contains no code changes. Instead, it just adds an `examples`directory, with a few example `requirements` files in it, as a visual aide when working on the `language-pip` package. 

Please refer to [#1] for more info (including the rationale).

Feel free to merge it if you like, or ditch it otherwise. Either way, it would have no effect on code behavior :-)

Cheers,
Tabulo[n]